### PR TITLE
refactor: remove prop-types from root workspace.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "/lib"
   ],
   "dependencies": {
-    "colord": "^2.9.3",
-    "prop-types": "^15.8.1"
+    "colord": "^2.9.3"
   },
   "peerDependencies": {
     "react": ">=17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       colord:
         specifier: ^2.9.3
         version: 2.9.3
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: ^25.0.3

--- a/src/ReactColorA11y.tsx
+++ b/src/ReactColorA11y.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, cloneElement, isValidElement, ReactNode } from 'react'
-import PropTypes from 'prop-types'
 import { colord, extend as extendColord, type Colord } from 'colord'
 import colordNamesPlugin from 'colord/plugins/names'
 import colordA11yPlugin from 'colord/plugins/a11y'
@@ -206,17 +205,6 @@ const ReactColorA11y: React.FunctionComponent<ReactColorA11yProps> = ({
       {children}
     </div>
   )
-}
-
-ReactColorA11y.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
-  ]).isRequired,
-  colorPaletteKey: PropTypes.string,
-  requiredContrastRatio: PropTypes.number,
-  flipBlackAndWhite: PropTypes.bool,
-  preserveContrastDirectionIfPossible: PropTypes.bool
 }
 
 export default ReactColorA11y


### PR DESCRIPTION
## Describe your changes
Removes `prop-types` from the root workspace to reduce production size.
## Issue ticket number and link
Fixes #8 
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
