### PR TITLE
Update Dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: 'thursday'
     groups:
       nonMajor:
         patterns:
@@ -14,4 +15,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: 'thursday'


### PR DESCRIPTION
This pull request updates the Dependabot configuration to increase the frequency of dependency update checks. Both npm and GitHub Actions dependencies will now be checked weekly on Thursdays instead of monthly.

Dependabot schedule updates:

* Changed the update interval for npm dependencies from monthly to weekly and set the update day to Thursday in `.github/dependabot.yml`.
* Changed the update interval for GitHub Actions dependencies from monthly to weekly and set the update day to Thursday in `.github/dependabot.yml`.